### PR TITLE
Link issue

### DIFF
--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -34,7 +34,7 @@
             <div>
               <h3>Developers</h3>
               <p>Check how to become part of Vidulum chain and project</p>
-              <a href="/getting-started">
+              <a href="/docs/getting-started">
                 Get involved
                 <img
                   class="action-arrow"


### PR DESCRIPTION
Landing page for the docs had a bad link I spotted.  Finally found where it was stored and corrected it.  Currently, the live page will give a 404 redirect when clicking on the link.  I am not sure why it's not routing properly, as my local copy works fine.
Maybe this isn't the 'proper' fix but it will resolve the issue.